### PR TITLE
NGINX: use $remote_addr instead of $proxy_add_x_forwarded_for.

### DIFF
--- a/istio.io/configmap-nginx.yaml
+++ b/istio.io/configmap-nginx.yaml
@@ -63,7 +63,7 @@ data:
         location / {
           proxy_set_header Host istio.io;
           proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-For $remote_addr;
           proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
           proxy_pass https://istio.github.io;
         }
@@ -94,7 +94,7 @@ data:
         location / {
           proxy_set_header Host testing.istio.io;
           proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-For $remote_addr;
           proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
           proxy_pass https://130.211.38.63;
         }
@@ -125,7 +125,7 @@ data:
         location / {
           proxy_set_header Host velodrome.istio.io;
           proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-For $remote_addr;
           proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
           proxy_pass http://130.211.224.127;
         }


### PR DESCRIPTION
We don't terminate trusted client, so we shouldn't use client's
"X-Forwarded-For" header.