### PR TITLE
NGINX: enable SSL session reuse.

### DIFF
--- a/istio.io/configmap-nginx.yaml
+++ b/istio.io/configmap-nginx.yaml
@@ -14,8 +14,13 @@ data:
       # Certs for all SSL server_names.
       ssl_certificate     /certs/tls.crt;
       ssl_certificate_key /certs/tls.key;
-      ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-      ssl_ciphers         HIGH:!aNULL:!MD5;
+
+      # SSL Session cache
+      ssl_session_cache   shared:SSL:10m;
+      ssl_session_timeout 18h;
+
+      # Proxy settings
+      proxy_ssl_session_reuse on;
 
       # This is the main site.
       #


### PR DESCRIPTION
While there, remove settings for SSL protocols and ciphers, which
match default values.