### PR TITLE
Only redirect version-prefixed URLs to versioned docs

### DIFF
--- a/istio.io/configmap-nginx.yaml
+++ b/istio.io/configmap-nginx.yaml
@@ -91,9 +91,7 @@ data:
 
         # Proxy version prefixed URL to versioned instances of
         # https://istio.io/docs/ and corresponding css/js/image
-        location ~ ^/v-[0-9]+\.[0-9]+(/|/docs/?.*|/js/.*|/img/.*|/css/.*)?$ {
-          rewrite ^(/v-[0-9]+\.[0-9])/?$ $1/docs/ redirect;
-
+        location ~ ^/v-[0-9]+\.[0-9]+(/docs|/js|/img|/css)(/|$) {
           proxy_set_header Host istiodocs-v01.firebaseapp.com;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $remote_addr;
@@ -118,7 +116,7 @@ data:
           # Redirect all version prefixed URLs for non-documentation to
           # the latest and greatest version of the site, e.g. faq,
           # blogs.
-          rewrite ^/v-[0-9]+\.[0-9](.*)$ https://istio.io$1 last;
+          rewrite ^/v-[0-9]+\.[0-9]+(/?.*)$ https://istio.io$1 last;
 
           proxy_set_header Host istio.io;
           proxy_set_header X-Real-IP $remote_addr;

--- a/istio.io/configmap-nginx.yaml
+++ b/istio.io/configmap-nginx.yaml
@@ -91,7 +91,7 @@ data:
 
         # Proxy version prefixed URL to versioned instances of
         # https://istio.io/docs/ and corresponding css/js/image
-        location ~ ^/v-[0-9]+\.[0-9]+(/docs|/js|/img|/css)(/|$) {
+        location ~ ^/v-[0-9]+\.[0-9]+/(docs|js|img|css)(/|$) {
           proxy_set_header Host istiodocs-v01.firebaseapp.com;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $remote_addr;

--- a/istio.io/configmap-nginx.yaml
+++ b/istio.io/configmap-nginx.yaml
@@ -89,8 +89,11 @@ data:
           return 200 "ok\n";
         }
 
-        # Proxy to past versioned instances of the site.
-        location ~ ^/v-[0-9]+\.[0-9]+.*$ {
+        # Proxy version prefixed URL to versioned instances of
+        # https://istio.io/docs/ and corresponding css/js/image
+        location ~ ^/v-[0-9]+\.[0-9]+(/|/docs/?.*|/js/.*|/img/.*|/css/.*)?$ {
+          rewrite ^(/v-[0-9]+\.[0-9])/?$ $1/docs/ redirect;
+
           proxy_set_header Host istiodocs-v01.firebaseapp.com;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $remote_addr;
@@ -112,6 +115,11 @@ data:
         # the github side are to the vanity domain.  DNS points the vanity
         # domain at this nginx.
         location / {
+          # Redirect all version prefixed URLs for non-documentation to
+          # the latest and greatest version of the site, e.g. faq,
+          # blogs.
+          rewrite ^/v-[0-9]+\.[0-9](.*)$ https://istio.io$1 last;
+
           proxy_set_header Host istio.io;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $remote_addr;

--- a/istio.io/configmap-nginx.yaml
+++ b/istio.io/configmap-nginx.yaml
@@ -116,7 +116,8 @@ data:
           # Redirect all version prefixed URLs for non-documentation to
           # the latest and greatest version of the site, e.g. faq,
           # blogs.
-          rewrite ^/v-[0-9]+\.[0-9]+(/?.*)$ https://istio.io$1 last;
+          # rewrite ^/v-[0-9]+\.[0-9]+$ https://istio.io last;
+          rewrite ^/v-[0-9]+\.[0-9]+($|/.*$) https://istio.io$1 last;
 
           proxy_set_header Host istio.io;
           proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
\+ @ldemailly for verifying desired mappings
\+ @PiotrSikora for verifying the actual nginx change is not totally wrong (or if there is a better way to handle this)

```
istio.io/v-0.1/       => istiodocs-v01.firebaseapp.com/v0.1/docs
istio.io/v-0.1/docs/* => istiodocs-v01.firebaseapp.com/v0.1/docs/*
istio.io/v-0.1/img/*  => istiodocs-v01.firebaseapp.com/v0.1/img/*
istio.io/v-0.1/js/*   => istiodocs-v01.firebaseapp.com/v0.1/js/*
istio.io/v-0.1/css/*  => istiodocs-v01.firebaseapp.com/v0.1/css/*

# everything else should be redirected back to istio.io
istio.io/v-0.1/about/*  => istio.io/about
istio.io/v-0.1/blog/*   => istio.io/blog
# ... etc ...
```
