### PR TITLE
redirect www.istio.io to istio and return 404 for unknown subdomains

### DIFF
--- a/istio.io/configmap-nginx.yaml
+++ b/istio.io/configmap-nginx.yaml
@@ -139,14 +139,6 @@ data:
         }
       }
 
-      # return 404 for any unknown servers (i.e. subdomains).
-      server {
-          listen 80 default_server;
-          listen 443 ssl http2 default_server;
-          server_name _;
-          return 404;
-      }
-
       # Make sure www.istio.io redirects to istio.io. This should be
       # handled by DNS and proper website URLs, but handle at proxy as
       # fallback.
@@ -235,5 +227,13 @@ data:
           add_header       X-Cache-Status $upstream_cache_status;
           proxy_cache      off;
         }
+      }
+
+      # return 404 for any unknown servers (i.e. subdomains).
+      server {
+          listen 80 default_server;
+          listen 443 ssl http2 default_server;
+          server_name _;
+          return 404;
       }
     }

--- a/istio.io/configmap-nginx.yaml
+++ b/istio.io/configmap-nginx.yaml
@@ -139,6 +139,24 @@ data:
         }
       }
 
+      # return 404 for any unknown servers (i.e. subdomains).
+      server {
+          listen 80 default_server;
+          listen 443 ssl http2 default_server;
+          server_name _;
+          return 404;
+      }
+
+      # Make sure www.istio.io redirects to istio.io. This should be
+      # handled by DNS and proper website URLs, but handle at proxy as
+      # fallback.
+      server {
+          listen 80;
+          listen 443 ssl http2;
+          server_name www.istio.io;
+          return 301 https://istio.io$request_uri;
+      }
+
       # Upgrade HTTP to HTTPS
       server {
         server_name testing.istio.io;

--- a/istio.io/deployment.yaml
+++ b/istio.io/deployment.yaml
@@ -55,6 +55,9 @@ spec:
           httpGet:
             path: /_healthz
             port: 80
+            httpHeaders:
+              - name: Host
+                value: istio.io
           initialDelaySeconds: 3
           timeoutSeconds: 2
           failureThreshold: 2


### PR DESCRIPTION
The previous configuration relied on nginx selecting an implicit
default server when no explicit server match was found. This resulting
in proxy serving istio.io content for https://www.istio.io. Fix this
with an explicit redirect and also add an explicit default server to
return 404 for unknown subdomains.

Fix for https://github.com/istio/admin-sites/issues/20