### PR TITLE
update fortio image and data dir to 1.2.0 locations

### DIFF
--- a/fortio/fortio.yaml
+++ b/fortio/fortio.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: fortio-report
-        image: istio/fortio:latest_release
+        image: fortio/fortio:latest_release
         imagePullPolicy: Always # needed despite what is documented to really get latest
         ports:
         - containerPort: 8079 # grpc echo
@@ -60,7 +60,7 @@ spec:
           #- -loglevel
           #- verbose
         volumeMounts:
-          - mountPath: /var/lib/istio/fortio
+          - mountPath: /var/lib/fortio
             name: fortio-data
       volumes:
         - name: fortio-data
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
       - name: fortio-debug
-        image: istio/fortio:latest_release
+        image: fortio/fortio:latest_release
         imagePullPolicy: Always
         ports:
         - containerPort: 8079 # grpc echo

--- a/fortio/stage/Makefile
+++ b/fortio/stage/Makefile
@@ -4,7 +4,7 @@
 
 
 FORTIO_VERSION:=latest
-FORTIO_IMAGE:=istio/fortio:$(FORTIO_VERSION)
+FORTIO_IMAGE:=fortio/fortio:$(FORTIO_VERSION)
 FORTIO_MAX_STREAMS:=0
 
 deploy-fortio:

--- a/fortio/stage/fortio.yaml
+++ b/fortio/stage/fortio.yaml
@@ -60,7 +60,7 @@ spec:
           #- -loglevel
           #- verbose
         volumeMounts:
-          - mountPath: /var/lib/istio/fortio
+          - mountPath: /var/lib/fortio
             name: fortio-data
       volumes:
         - name: fortio-data


### PR DESCRIPTION
already deployed (successfully) on https://fortio.istio.io and https://fortio-stage.istio.io/